### PR TITLE
Add Flask dismissal checker application with teacher import and attendance tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+instance/
+.dismissal_checker.db-journal
+dismissal_checker.db
+.venv/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Dismissal Checker
+
+A Flask web application that helps manage the school dismissal plan, track teacher assignments, and record attendance with automatic warning tracking.
+
+## Features
+
+- Import teacher data from `.xls` files (NUM, Full name, Mobile, Email columns).
+- Store dismissal plan assignments for each weekday in a SQLite database.
+- View the dismissal plan for any day and record attendance for each assignment.
+- Automatically increment or decrement teacher warning counts based on attendance records.
+- Review the teacher directory and current warning totals.
+
+## Getting started
+
+### Requirements
+
+- Python 3.11+
+- The dependencies listed in `requirements.txt`
+
+### Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Database setup
+
+The project ships with a dismissal plan stored in `data/dismissal_plan.json`. Load it into the database with the provided Flask CLI command:
+
+```bash
+flask --app app:create_app load-plan
+```
+
+The first time you run the command, the SQLite database file (`dismissal_checker.db`) will be created automatically.
+
+### Running the application
+
+```bash
+flask --app app:create_app run
+```
+
+Navigate to <http://127.0.0.1:5000/> to view the current day's plan, import teachers, and record attendance.
+
+### Importing teachers
+
+1. Navigate to **Import Teachers** in the navigation bar.
+2. Upload an `.xls` file that contains the teacher roster with the following columns:
+   - `NUM`
+   - `Full name`
+   - `Mobile`
+   - `Email`
+3. After uploading, the teachers will be stored in the database and automatically linked to the dismissal plan (if names match).
+
+### Recording attendance
+
+1. Open the plan for a specific day.
+2. Choose the desired date (defaults to today).
+3. Mark each assignment as **Present** or **Absent** and submit the form.
+4. Teachers marked absent will have their warning count incremented; removing an absence decreases the warning total.
+
+### Additional CLI utilities
+
+- `flask --app app:create_app clear-attendance` — Remove all attendance records (use `--day` to limit to a specific weekday).
+- `flask --app app:create_app today-plan` — Print the assignments scheduled for the current day to the terminal.
+
+## Notes
+
+- The default SQLite database is stored at `dismissal_checker.db` in the project root. Set the `DATABASE_URL` environment variable to use a different database.
+- The application accepts classic `.xls` spreadsheets. Ensure your Excel exporter saves in this format or convert as needed.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,7 @@
+from app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,32 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+from config import Config
+
+# SQLAlchemy instance shared across modules
+db = SQLAlchemy()
+
+
+def create_app(config_class: type[Config] = Config) -> Flask:
+    """Application factory for the dismissal checker app."""
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+
+    db.init_app(app)
+
+    from .routes import main_bp  # pylint: disable=import-outside-toplevel
+
+    app.register_blueprint(main_bp)
+
+    with app.app_context():
+        db.create_all()
+        register_cli_commands(app)
+
+    return app
+
+
+def register_cli_commands(app: Flask) -> None:
+    """Register custom Flask CLI commands."""
+    from .cli import register as register_cli
+
+    register_cli(app)

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import click
+
+from . import db
+from .models import AttendanceRecord, DutyAssignment, DutyPlan, DutySection
+from .plan_loader import load_plan
+
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+PLAN_FILE = DATA_DIR / "dismissal_plan.json"
+
+
+def register(app):
+    @app.cli.command("load-plan")
+    @click.option("--plan-file", type=click.Path(exists=True, dir_okay=False), default=str(PLAN_FILE))
+    def load_plan_command(plan_file: str) -> None:
+        """Load the dismissal plan from a JSON file into the database."""
+        plan_path = Path(plan_file)
+        if not plan_path.exists():
+            click.echo(f"Plan file {plan_path} does not exist.")
+            return
+        load_plan(plan_path)
+        click.echo("Dismissal plan loaded.")
+
+    @app.cli.command("clear-attendance")
+    @click.option("--day", type=str, help="Limit clearing to a specific day of the week (e.g. Sunday).")
+    def clear_attendance(day: str | None) -> None:
+        """Clear attendance records, optionally filtered by day of week."""
+        query = AttendanceRecord.query
+        if day:
+            day = day.capitalize()
+            query = query.join(DutyAssignment).join(DutySection).join(DutyPlan).filter(DutyPlan.day_of_week == day)
+        count = query.delete(synchronize_session=False)
+        db.session.commit()
+        click.echo(f"Removed {count} attendance records.")
+
+    @app.cli.command("today-plan")
+    def today_plan() -> None:
+        """Print the assignments scheduled for today."""
+        current_day = date.today().strftime("%A")
+        plan = DutyPlan.query.filter_by(day_of_week=current_day).first()
+        if not plan:
+            click.echo(f"No plan found for {current_day}.")
+            return
+        click.echo(f"Supervisor: {plan.supervisor}")
+        click.echo(f"Team: {plan.team}")
+        for section in plan.sections:
+            click.echo(f"\n{section.name}")
+            for assignment in section.assignments:
+                teacher_name = assignment.teacher.full_name if assignment.teacher else assignment.placeholder_name
+                click.echo(f"  {assignment.order}. {teacher_name} - {assignment.place_task or 'No task specified'}")

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import CheckConstraint, Date, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import db
+
+
+class Teacher(db.Model):
+    __tablename__ = "teachers"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    full_name: Mapped[str] = mapped_column(db.String(120), nullable=False)
+    mobile: Mapped[str | None] = mapped_column(db.String(32))
+    email: Mapped[str] = mapped_column(db.String(120), unique=True, nullable=False)
+    warnings: Mapped[int] = mapped_column(db.Integer, default=0, nullable=False)
+
+    assignments: Mapped[list["DutyAssignment"]] = relationship(back_populates="teacher")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"<Teacher {self.full_name} ({self.email})>"
+
+
+class DutyPlan(db.Model):
+    __tablename__ = "duty_plans"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    day_of_week: Mapped[str] = mapped_column(db.String(16), nullable=False, unique=True)
+    supervisor: Mapped[str] = mapped_column(db.String(120), nullable=False)
+    team: Mapped[str] = mapped_column(db.String(255), nullable=True)
+
+    sections: Mapped[list["DutySection"]] = relationship(
+        back_populates="plan", cascade="all, delete-orphan", order_by="DutySection.order"
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<DutyPlan {self.day_of_week}>"
+
+
+class DutySection(db.Model):
+    __tablename__ = "duty_sections"
+    __table_args__ = (UniqueConstraint("plan_id", "name", name="uix_plan_section"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    plan_id: Mapped[int] = mapped_column(ForeignKey("duty_plans.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(db.String(120), nullable=False)
+    order: Mapped[int] = mapped_column(db.Integer, nullable=False, default=0)
+
+    plan: Mapped[DutyPlan] = relationship(back_populates="sections")
+    assignments: Mapped[list["DutyAssignment"]] = relationship(
+        back_populates="section", cascade="all, delete-orphan", order_by="DutyAssignment.order"
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<DutySection {self.name} ({self.plan.day_of_week})>"
+
+
+class DutyAssignment(db.Model):
+    __tablename__ = "duty_assignments"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    section_id: Mapped[int] = mapped_column(ForeignKey("duty_sections.id", ondelete="CASCADE"), nullable=False)
+    teacher_id: Mapped[int | None] = mapped_column(ForeignKey("teachers.id"), nullable=True)
+    placeholder_name: Mapped[str] = mapped_column(db.String(120), nullable=True)
+    order: Mapped[int] = mapped_column(db.Integer, nullable=False, default=0)
+    place_task: Mapped[str | None] = mapped_column(db.String(255))
+
+    section: Mapped[DutySection] = relationship(back_populates="assignments")
+    teacher: Mapped[Teacher | None] = relationship(back_populates="assignments")
+    attendance_records: Mapped[list["AttendanceRecord"]] = relationship(back_populates="assignment", cascade="all, delete-orphan")
+
+    @property
+    def display_name(self) -> str:
+        return self.teacher.full_name if self.teacher else (self.placeholder_name or "Unassigned")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<DutyAssignment {self.display_name} ({self.section.plan.day_of_week})>"
+
+
+class AttendanceRecord(db.Model):
+    __tablename__ = "attendance_records"
+    __table_args__ = (
+        UniqueConstraint("assignment_id", "date", name="uix_assignment_date"),
+        CheckConstraint("status in ('present', 'absent')", name="ck_status_valid"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    assignment_id: Mapped[int] = mapped_column(ForeignKey("duty_assignments.id", ondelete="CASCADE"), nullable=False)
+    date: Mapped[date] = mapped_column(Date, nullable=False)
+    status: Mapped[str] = mapped_column(db.String(16), nullable=False)
+
+    assignment: Mapped[DutyAssignment] = relationship(back_populates="attendance_records")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<AttendanceRecord {self.assignment_id} {self.date} {self.status}>"

--- a/app/plan_loader.py
+++ b/app/plan_loader.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+
+from . import db
+from .models import DutyAssignment, DutyPlan, DutySection, Teacher
+
+
+DAY_ORDER = {"Sunday": 0, "Monday": 1, "Tuesday": 2, "Wednesday": 3, "Thursday": 4, "Friday": 5, "Saturday": 6}
+
+
+def load_plan(path: Path) -> None:
+    """Load a dismissal plan from a JSON file into the database."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    existing_plans = {plan.day_of_week: plan for plan in db.session.scalars(select(DutyPlan)).all()}
+
+    for plan_data in payload:
+        day = plan_data["day"]
+        plan = existing_plans.get(day)
+        if plan is None:
+            plan = DutyPlan(day_of_week=day)
+            db.session.add(plan)
+            existing_plans[day] = plan
+        plan.supervisor = plan_data.get("supervisor", "")
+        plan.team = plan_data.get("team")
+
+        # Clear existing sections/assignments to reload fresh data
+        plan.sections.clear()
+        for section_order, section in enumerate(plan_data.get("sections", []), start=1):
+            section_model = DutySection(name=section["name"], order=section_order)
+            plan.sections.append(section_model)
+            for assignment_data in section.get("assignments", []):
+                assignment = DutyAssignment(
+                    order=assignment_data.get("order", 0),
+                    place_task=assignment_data.get("place_task"),
+                )
+                teacher_name = assignment_data.get("teacher")
+                if teacher_name:
+                    teacher = resolve_teacher_by_name(teacher_name)
+                    if teacher:
+                        assignment.teacher = teacher
+                    else:
+                        assignment.placeholder_name = teacher_name
+                else:
+                    assignment.placeholder_name = assignment_data.get("placeholder_name")
+                section_model.assignments.append(assignment)
+
+    db.session.commit()
+
+
+def resolve_teacher_by_name(name: str) -> Teacher | None:
+    """Attempt to match a teacher by their full name ignoring double spaces and case."""
+    normalized = " ".join(part for part in name.split())
+    stmt = select(Teacher).where(db.func.lower(Teacher.full_name) == normalized.lower())
+    return db.session.scalar(stmt)
+
+
+def export_plan() -> list[dict[str, Any]]:
+    """Serialize the current plan state to a JSON-compatible structure."""
+    plans = []
+    for plan in DutyPlan.query.order_by(db.case(DAY_ORDER, value=DutyPlan.day_of_week)).all():
+        sections = []
+        for section in plan.sections:
+            assignments = []
+            for assignment in section.assignments:
+                assignments.append(
+                    {
+                        "order": assignment.order,
+                        "teacher": assignment.teacher.full_name if assignment.teacher else assignment.placeholder_name,
+                        "place_task": assignment.place_task,
+                    }
+                )
+            sections.append({"name": section.name, "assignments": assignments})
+        plans.append({"day": plan.day_of_week, "supervisor": plan.supervisor, "team": plan.team, "sections": sections})
+    return plans

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from pathlib import Path
+
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from werkzeug.utils import secure_filename
+from xlrd import XL_CELL_NUMBER, open_workbook
+
+from . import db
+from .models import AttendanceRecord, DutyAssignment, DutyPlan, Teacher
+
+main_bp = Blueprint("main", __name__)
+
+
+@main_bp.app_errorhandler(404)
+def not_found(error):  # pragma: no cover - template driven
+    return render_template("404.html"), 404
+
+
+@main_bp.route("/")
+def index():
+    return redirect(url_for("main.today_plan"))
+
+
+@main_bp.route("/plan/today", methods=["GET", "POST"])
+def today_plan():
+    today = date.today()
+    return plan_for_day(today.strftime("%A"), today)
+
+
+@main_bp.route("/plan/<day>", methods=["GET", "POST"])
+def plan_for_day(day: str, target_date: date | None = None):
+    day = day.capitalize()
+    if target_date is None:
+        date_param = request.args.get("date") or request.form.get("date")
+        if date_param:
+            try:
+                target_date = datetime.strptime(date_param, "%Y-%m-%d").date()
+            except ValueError:
+                flash("Invalid date format. Please use YYYY-MM-DD.", "warning")
+                target_date = date.today()
+        else:
+            target_date = date.today()
+
+    all_plans = DutyPlan.query.order_by(DutyPlan.day_of_week).all()
+    plan = DutyPlan.query.filter_by(day_of_week=day).first()
+    if plan is None:
+        flash(f"No dismissal plan found for {day}.", "warning")
+        return render_template("plan.html", plan=None, day=day, target_date=target_date, all_plans=all_plans)
+
+    if request.method == "POST":
+        handle_attendance_submission(plan, target_date)
+        return redirect(url_for("main.plan_for_day", day=day, date=target_date.isoformat()))
+
+    attendance_map = load_attendance_map(plan, target_date)
+    return render_template(
+        "plan.html",
+        plan=plan,
+        attendance_map=attendance_map,
+        day=day,
+        target_date=target_date,
+        all_plans=all_plans,
+    )
+
+
+@main_bp.route("/teachers")
+def teachers():
+    teacher_list = Teacher.query.order_by(Teacher.full_name).all()
+    return render_template("teachers.html", teachers=teacher_list)
+
+
+@main_bp.route("/import/teachers", methods=["GET", "POST"])
+def import_teachers():
+    if request.method == "POST":
+        file = request.files.get("file")
+        if not file or file.filename == "":
+            flash("Please choose an .xls file to upload.", "danger")
+            return redirect(request.url)
+
+        filename = secure_filename(file.filename)
+        if not filename.lower().endswith(".xls"):
+            flash("Only .xls files are supported.", "danger")
+            return redirect(request.url)
+
+        upload_dir = Path(current_app.instance_path)
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        file_path = upload_dir / filename
+        file.save(file_path)
+
+        try:
+            imported_count = import_teachers_from_xls(file_path)
+            flash(f"Successfully imported {imported_count} teachers.", "success")
+        except Exception as exc:  # pragma: no cover - user feedback
+            current_app.logger.exception("Failed to import teachers")
+            flash(f"Failed to import teachers: {exc}", "danger")
+        finally:
+            if file_path.exists():
+                file_path.unlink()
+
+        return redirect(url_for("main.teachers"))
+
+    return render_template("import_teachers.html")
+
+
+def import_teachers_from_xls(path: Path) -> int:
+    workbook = open_workbook(path, encoding_override="utf-8")
+    sheet = workbook.sheet_by_index(0)
+
+    headers = [str(sheet.cell_value(0, col)).strip().lower() for col in range(sheet.ncols)]
+    expected_columns = {"num", "full name", "mobile", "email"}
+    if not expected_columns.issubset(set(headers)):
+        raise ValueError("The uploaded file does not contain the required columns: NUM, Full name, Mobile, Email")
+
+    name_idx = headers.index("full name")
+    mobile_idx = headers.index("mobile")
+    email_idx = headers.index("email")
+
+    count = 0
+    for row_idx in range(1, sheet.nrows):
+        full_name = to_string(sheet.cell(row_idx, name_idx))
+        mobile = to_string(sheet.cell(row_idx, mobile_idx))
+        email = to_string(sheet.cell(row_idx, email_idx)).lower()
+        if not full_name or not email:
+            continue
+
+        teacher = Teacher.query.filter_by(email=email).first()
+        if teacher:
+            teacher.full_name = normalize_name(full_name)
+            teacher.mobile = mobile
+        else:
+            teacher = Teacher(full_name=normalize_name(full_name), mobile=mobile, email=email)
+            db.session.add(teacher)
+        count += 1
+
+    db.session.commit()
+    return count
+
+
+def normalize_name(name: str) -> str:
+    return " ".join(part for part in name.split())
+
+
+def to_string(cell) -> str:
+    value = cell.value
+    if cell.ctype == XL_CELL_NUMBER:
+        if float(value).is_integer():
+            return str(int(value))
+        return str(value)
+    return str(value).strip()
+
+
+def handle_attendance_submission(plan: DutyPlan, target_date: date) -> None:
+    for assignment in plan_assignments(plan):
+        form_key = f"assignment-{assignment.id}"
+        status = request.form.get(form_key)
+        if status not in {"present", "absent", None}:
+            continue
+        record = AttendanceRecord.query.filter_by(assignment_id=assignment.id, date=target_date).first()
+        previous_status = record.status if record else None
+
+        if status is None:
+            if record:
+                db.session.delete(record)
+                adjust_warnings(assignment, previous_status, None)
+            continue
+
+        if record is None:
+            record = AttendanceRecord(assignment=assignment, date=target_date)
+            db.session.add(record)
+        record.status = status
+        adjust_warnings(assignment, previous_status, status)
+
+    db.session.commit()
+
+
+def load_attendance_map(plan: DutyPlan, target_date: date) -> dict[int, AttendanceRecord | None]:
+    records = (
+        AttendanceRecord.query.join(DutyAssignment)
+        .filter(DutyAssignment.section.has(plan_id=plan.id), AttendanceRecord.date == target_date)
+        .all()
+    )
+    return {record.assignment_id: record for record in records}
+
+
+def adjust_warnings(assignment: DutyAssignment, previous_status: str | None, new_status: str | None) -> None:
+    teacher = assignment.teacher
+    if not teacher:
+        return
+
+    if previous_status == "absent" and new_status != "absent" and teacher.warnings > 0:
+        teacher.warnings -= 1
+    if new_status == "absent" and previous_status != "absent":
+        teacher.warnings += 1
+
+
+def plan_assignments(plan: DutyPlan):
+    for section in plan.sections:
+        for assignment in section.assignments:
+            yield assignment

--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}Page not found{% endblock %}
+{% block content %}
+  <div class="text-center py-5">
+    <h1 class="display-4">404</h1>
+    <p class="lead">The page you were looking for could not be found.</p>
+    <a class="btn btn-primary" href="{{ url_for('main.today_plan') }}">Back to today's plan</a>
+  </div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Dismissal Checker{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-o+RDsa0aLu++PJvF4C++bkBu2V1bdx+mkBxIYi4s0Dr1sGZF+7yZ9E6QF5rFQK8" crossorigin="anonymous">
+    <style>
+      body { padding-top: 4.5rem; }
+      .section-title { margin-top: 2rem; }
+      .badge-warning { background-color: #ffc107; }
+      .badge-danger { background-color: #dc3545; }
+    </style>
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('main.today_plan') }}">Dismissal Checker</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav me-auto">
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('main.today_plan') }}">Today's Plan</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('main.teachers') }}">Teachers</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('main.import_teachers') }}">Import Teachers</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container">
+      {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+          <div class="mt-2">
+            {% for category, message in messages %}
+              <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+
+      {% block content %}{% endblock %}
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/app/templates/import_teachers.html
+++ b/app/templates/import_teachers.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Import Teachers{% endblock %}
+{% block content %}
+  <h1>Import Teachers</h1>
+  <p>Upload an <code>.xls</code> file with the following columns: <strong>NUM</strong>, <strong>Full name</strong>, <strong>Mobile</strong>, <strong>Email</strong>.</p>
+  <form method="post" enctype="multipart/form-data" class="mt-4">
+    <div class="mb-3">
+      <label for="file" class="form-label">Choose file</label>
+      <input class="form-control" type="file" id="file" name="file" accept=".xls">
+    </div>
+    <button type="submit" class="btn btn-primary">Import</button>
+  </form>
+{% endblock %}

--- a/app/templates/plan.html
+++ b/app/templates/plan.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+{% block title %}Dismissal Plan - {{ day }}{% endblock %}
+{% block content %}
+  <div class="d-flex justify-content-between align-items-center">
+    <h1 class="mb-3">{{ day }} Dismissal Plan</h1>
+    <form class="d-flex" method="get">
+      <input type="date" class="form-control me-2" name="date" value="{{ target_date.isoformat() }}">
+      <button class="btn btn-outline-primary" type="submit">Change date</button>
+    </form>
+  </div>
+
+  <div class="mb-3">
+    <label class="form-label">Switch day</label>
+    <select class="form-select" onchange="if (this.value) { window.location.href = this.value; }">
+      <option value="">Select a day</option>
+      {% for plan_option in all_plans %}
+        {% set is_selected = plan and plan_option.day_of_week == plan.day_of_week %}
+        <option value="{{ url_for('main.plan_for_day', day=plan_option.day_of_week, date=target_date.isoformat()) }}" {% if is_selected %}selected{% endif %}>{{ plan_option.day_of_week }}</option>
+      {% endfor %}
+    </select>
+  </div>
+
+  {% if plan %}
+    <div class="card mb-4">
+      <div class="card-body">
+        <h5 class="card-title">Supervisor: {{ plan.supervisor }}</h5>
+        {% if plan.team %}<p class="card-text">Team: {{ plan.team }}</p>{% endif %}
+      </div>
+    </div>
+
+    <form method="post">
+      <input type="hidden" name="date" value="{{ target_date.isoformat() }}">
+      {% for section in plan.sections|sort(attribute='order') %}
+        <div class="section-title">
+          <h2>{{ section.name }}</h2>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-striped align-middle">
+            <thead>
+              <tr>
+                <th style="width:4rem;">#</th>
+                <th>Teacher</th>
+                <th>Task / Location</th>
+                <th style="width:12rem;">Attendance</th>
+                <th style="width:8rem;">Warnings</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for assignment in section.assignments %}
+                {% set record = attendance_map.get(assignment.id) %}
+                {% set teacher = assignment.teacher %}
+                <tr class="{% if record and record.status == 'absent' %}table-danger{% endif %}">
+                  <td>{{ assignment.order }}</td>
+                  <td>
+                    <strong>{{ assignment.display_name }}</strong>
+                    {% if teacher %}
+                      <div class="text-muted small">{{ teacher.email }}{% if teacher.mobile %} · {{ teacher.mobile }}{% endif %}</div>
+                    {% endif %}
+                  </td>
+                  <td>{{ assignment.place_task or '—' }}</td>
+                  <td>
+                    <div class="form-check form-check-inline">
+                      <input class="form-check-input" type="radio" name="assignment-{{ assignment.id }}" id="assignment-{{ assignment.id }}-present" value="present" {% if record and record.status == 'present' %}checked{% endif %}>
+                      <label class="form-check-label" for="assignment-{{ assignment.id }}-present">Present</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                      <input class="form-check-input" type="radio" name="assignment-{{ assignment.id }}" id="assignment-{{ assignment.id }}-absent" value="absent" {% if record and record.status == 'absent' %}checked{% endif %}>
+                      <label class="form-check-label" for="assignment-{{ assignment.id }}-absent">Absent</label>
+                    </div>
+                  </td>
+                  <td>
+                    {% if teacher %}
+                      {% if teacher.warnings >= 3 %}
+                        <span class="badge badge-danger">{{ teacher.warnings }}</span>
+                      {% elif teacher.warnings >= 1 %}
+                        <span class="badge badge-warning">{{ teacher.warnings }}</span>
+                      {% else %}
+                        <span class="badge bg-secondary">0</span>
+                      {% endif %}
+                    {% else %}
+                      <span class="badge bg-light text-dark">N/A</span>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endfor %}
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" type="submit">Save attendance</button>
+      </div>
+    </form>
+  {% else %}
+    <div class="alert alert-info">No plan available for {{ day }}. Please load the plan using the CLI command.</div>
+  {% endif %}
+{% endblock %}

--- a/app/templates/teachers.html
+++ b/app/templates/teachers.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Teachers{% endblock %}
+{% block content %}
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Teachers</h1>
+    <a class="btn btn-outline-primary" href="{{ url_for('main.import_teachers') }}">Import teachers</a>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Mobile</th>
+          <th>Warnings</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for teacher in teachers %}
+          <tr>
+            <td>{{ teacher.full_name }}</td>
+            <td>{{ teacher.email }}</td>
+            <td>{{ teacher.mobile or '—' }}</td>
+            <td>
+              {% if teacher.warnings >= 3 %}
+                <span class="badge badge-danger">{{ teacher.warnings }}</span>
+              {% elif teacher.warnings >= 1 %}
+                <span class="badge badge-warning">{{ teacher.warnings }}</span>
+              {% else %}
+                <span class="badge bg-secondary">0</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="4" class="text-center">No teachers found. Import them from an .xls file.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,12 @@
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "DATABASE_URL",
+        f"sqlite:///{BASE_DIR / 'dismissal_checker.db'}"
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/data/dismissal_plan.json
+++ b/data/dismissal_plan.json
@@ -1,0 +1,296 @@
+[
+  {
+    "day": "Sunday",
+    "supervisor": "Hany Amin",
+    "team": "ELA + German + SSA + Music",
+    "sections": [
+      {
+        "name": "Building Supervision",
+        "assignments": [
+          {"order": 1, "teacher": "Dina Refaat", "place_task": "Fifth floor in front of the middle stairs"},
+          {"order": 2, "teacher": "Mohamed Salama", "place_task": "Fifth floor in front of the computer lab"},
+          {"order": 3, "teacher": "Safa Abd Elaleem", "place_task": "Fourth floor in front of the Canteen stairs"},
+          {"order": 4, "teacher": "Basma Seif", "place_task": "Third Floor in front of the middle stairs"},
+          {"order": 5, "teacher": "Hagar El-Gohary", "place_task": "Third Floor in front of the accountant's stairs"},
+          {"order": 6, "teacher": "Asmaa Hamdy", "place_task": "Second floor in front of the Canteen stairs"},
+          {"order": 7, "teacher": "Nora Amgad", "place_task": "Second floor in front of the accountant's stairs"}
+        ]
+      },
+      {
+        "name": "Garden Supervision",
+        "assignments": [
+          {"order": 8, "teacher": "PE", "place_task": "G 1&2"},
+          {"order": 9, "teacher": "PE", "place_task": "G3&4"},
+          {"order": 10, "teacher": "PE", "place_task": "G5&6"},
+          {"order": 11, "teacher": "Hanan Romany", "place_task": "G7&8"},
+          {"order": 12, "teacher": "Shimaa Desouky", "place_task": "G9&10"}
+        ]
+      },
+      {
+        "name": "Receiving and giving the students to the drivers",
+        "assignments": [
+          {"order": 13, "teacher": "Hany Amin", "place_task": "Responsible for taking the papers from the drivers and preventing the drivers from entering the school"},
+          {"order": 14, "teacher": "Fatma Al-Zahraa", "place_task": "Receiving the papers and getting the students to the drivers."},
+          {"order": 15, "teacher": "Basma Tarek"},
+          {"order": 16, "teacher": "Mohamed Abdelhakam"},
+          {"order": 17, "teacher": "Rania Yosry"},
+          {"order": 18, "teacher": "Mai Awny"},
+          {"order": 19, "teacher": "M.Shokry"},
+          {"order": 20, "teacher": "Mohamed Salah"},
+          {"order": 21, "teacher": "Ahmed El-Kady"},
+          {"order": 22, "teacher": "Essam"},
+          {"order": 23, "teacher": "Mostafa"},
+          {"order": 24, "teacher": "Mohamed Samir ( music)"},
+          {"order": 25, "teacher": "Basma Mohamed"},
+          {"order": 26, "teacher": "Dina Emad"},
+          {"order": 27, "teacher": "Norhan Haitham"},
+          {"order": 28, "teacher": "Abdelwahab Mahrous"},
+          {"order": 29, "teacher": "Amira Samaan"},
+          {"order": 30, "teacher": "Nesma Hesham"},
+          {"order": 31, "teacher": "Hadeer Emad"},
+          {"order": 32, "teacher": "Esraa Adel"},
+          {"order": 33, "teacher": "Hagar yasser"},
+          {"order": 34, "teacher": "Al-Shimaa Abdelkhalik"}
+        ]
+      }
+    ]
+  },
+  {
+    "day": "Monday",
+    "supervisor": "Ramadan Omar",
+    "team": "Arabic + SSE + Computer+ Math +sience",
+    "sections": [
+      {
+        "name": "Building Supervision",
+        "assignments": [
+          {"order": 1, "teacher": "Ramadan Omar", "place_task": "Fifth floor in front of the Canteen stairs"},
+          {"order": 2, "teacher": "Reham Younis& Asmaa Khaled", "place_task": "Fourth floor in front of G 12A"},
+          {"order": 3, "teacher": "Howaida Hassan", "place_task": "Third Floor in front of the middle stairs."},
+          {"order": 4, "teacher": "Eman Ramadan", "place_task": "Third Floor in front of the Canteen stairs"},
+          {"order": 5, "teacher": "Shimaa Abdelmoneam", "place_task": "Second floor in front of the Canteen stairs"},
+          {"order": 6, "teacher": "Doaa Marzoq", "place_task": "Second floor in front of the accountant's stairs"}
+        ]
+      },
+      {
+        "name": "Garden Supervision",
+        "assignments": [
+          {"order": 7, "teacher": "PE", "place_task": "G 1& 2"},
+          {"order": 8, "teacher": "PE", "place_task": "G3&4"},
+          {"order": 9, "teacher": "PE", "place_task": "G5&6"},
+          {"order": 10, "teacher": "Dina Mohamed", "place_task": "G7&8"},
+          {"order": 11, "teacher": "Nahed Elrabie", "place_task": "G9&10"}
+        ]
+      },
+      {
+        "name": "Receiving and giving the students to the drivers",
+        "assignments": [
+          {"order": 12, "teacher": "Ahmad Fahr", "place_task": "Responsible for taking the papers from the drivers and preventing the drivers from entering the school"},
+          {"order": 13, "teacher": "Roqaia", "place_task": "Receiving the papers and getting the students to the drivers."},
+          {"order": 14, "teacher": "Ahmad Ragab"},
+          {"order": 15, "teacher": "Mohamed Abdullah"},
+          {"order": 16, "teacher": "Ahmed Mohamed Tokhy"},
+          {"order": 17, "teacher": "Rahma Mohamed Sherien"},
+          {"order": 18, "teacher": "Yasmin Mahmoud"},
+          {"order": 19, "teacher": "Sohaila Elsebaie"},
+          {"order": 20, "teacher": "Abdullah Mohamed"},
+          {"order": 21, "teacher": "Tasneem Abdo"},
+          {"order": 22, "teacher": "Nancy Haseeb"},
+          {"order": 23, "teacher": "Fatma Ahmed"},
+          {"order": 24, "teacher": "Aya Amgad"},
+          {"order": 25, "teacher": "Heba Kamel"},
+          {"order": 26, "teacher": "Mohamed Salah"},
+          {"order": 27, "teacher": "Mohamad Rady"},
+          {"order": 28, "teacher": "Hagar Asy"},
+          {"order": 29, "teacher": "Samar Ahmed"},
+          {"order": 30, "teacher": "Aya Adel"},
+          {"order": 31, "teacher": "Asmaa Magdy"},
+          {"order": 32, "teacher": "Rofida"},
+          {"order": 33, "teacher": "Hagar Gaber"},
+          {"order": 34, "teacher": "Nesreen Adel"}
+        ]
+      }
+    ]
+  },
+  {
+    "day": "Tuesday",
+    "supervisor": "Eman Azab",
+    "team": "Math + Science + Arabic+ Arabic + SSE",
+    "sections": [
+      {
+        "name": "Building Supervision",
+        "assignments": [
+          {"order": 1, "teacher": "Eman Ramadan", "place_task": "Fourth floor in front of G 12A"},
+          {"order": 2, "teacher": "Doaa Gamal", "place_task": "Third Floor in front of the accountant's stairs"},
+          {"order": 3, "teacher": "Enas Ahmed", "place_task": "Second floor in front of the Canteen stairs"},
+          {"order": 4, "teacher": "Rasha Reda", "place_task": "Second floor in front of the accountant's stairs"},
+          {"order": 5, "teacher": "Mariem Galal", "place_task": "Ground floor in front of the middle stairs"}
+        ]
+      },
+      {
+        "name": "Garden Supervision",
+        "assignments": [
+          {"order": 6, "teacher": "PE", "place_task": "G1& 2"},
+          {"order": 7, "teacher": "PE", "place_task": "G3&4"},
+          {"order": 8, "teacher": "PE", "place_task": "G5&6"},
+          {"order": 9, "teacher": "Nesreen Adel", "place_task": "G7&8"}
+        ]
+      },
+      {
+        "name": "Receiving and giving the students to the drivers",
+        "assignments": [
+          {"order": 10, "teacher": "Okasha", "place_task": "Responsible for taking the papers from the drivers and preventing the drivers from entering the school"},
+          {"order": 11, "teacher": "Omar Ahmed", "place_task": "Receiving the papers and getting the students to the drivers."},
+          {"order": 12, "teacher": "Mohamad Rady"},
+          {"order": 13, "teacher": "Mohamed Abdel Rabea"},
+          {"order": 14, "teacher": "Elina Emad"},
+          {"order": 15, "teacher": "Yasmin Ahmed"},
+          {"order": 16, "teacher": "Hana Adel"},
+          {"order": 17, "teacher": "Howaida Hassan"},
+          {"order": 18, "teacher": "Amira Abdelrazik"},
+          {"order": 19, "teacher": "Amany Mohamed"},
+          {"order": 20, "teacher": "Eman Azab"},
+          {"order": 21, "teacher": "Amira Samir"},
+          {"order": 22, "teacher": "Hagar Gaber"},
+          {"order": 23, "teacher": "Shimaa Abedmoneam"},
+          {"order": 24, "teacher": "Heba Kamel"},
+          {"order": 25, "teacher": "Dina Mohamed"},
+          {"order": 26, "teacher": "Nahed Elrabie"},
+          {"order": 27, "teacher": "Hagar Assey"},
+          {"order": 28, "teacher": "Amira Farouk"},
+          {"order": 29, "teacher": "Toka Adel"},
+          {"order": 30, "teacher": "Nancy Haseeb"},
+          {"order": 31, "teacher": "Fatma Ahmed"}
+        ]
+      }
+    ]
+  },
+  {
+    "day": "Wednesday",
+    "supervisor": "Aya Amgad",
+    "team": "ELA + German + SSA + Music +French",
+    "sections": [
+      {
+        "name": "Building Supervision",
+        "assignments": [
+          {"order": 1, "teacher": "Mohamed Salama", "place_task": "Fifth floor in front of the canteen"},
+          {"order": 2, "teacher": "Safa Abd Elaleem", "place_task": "Fourth floor in front of G 12A"},
+          {"order": 3, "teacher": "Basma Seif", "place_task": "Fourth floor in front of the Canteen stairs"},
+          {"order": 4, "teacher": "Norhan Haitham", "place_task": "Third Floor in front of the middle stairs"},
+          {"order": 5, "teacher": "Rania Yosry", "place_task": "Third Floor in front of the accountant's stairs"},
+          {"order": 6, "teacher": "Basma Tarek", "place_task": "Second floor in front of the Canteen stairs"},
+          {"order": 7, "teacher": "Hagar yasser", "place_task": "Second floor in front of the accountant's stairs"}
+        ]
+      },
+      {
+        "name": "Garden Supervision",
+        "assignments": [
+          {"order": 8, "teacher": "PE", "place_task": "G1& 2"},
+          {"order": 9, "teacher": "PE", "place_task": "G3&4"},
+          {"order": 10, "teacher": "PE", "place_task": "G5&6"},
+          {"order": 11, "teacher": "Essam", "place_task": "G7&8"},
+          {"order": 12, "teacher": "Hanan Romany", "place_task": "G9&10"}
+        ]
+      },
+      {
+        "name": "Receiving and giving the students to the drivers",
+        "assignments": [
+          {"order": 13, "teacher": "Abdelwahab Mahrous", "place_task": "Responsible for taking the papers from the drivers and preventing the drivers from entering the school"},
+          {"order": 14, "teacher": "Basma Mohamed", "place_task": "Receiving the papers and getting the students to the drivers."},
+          {"order": 15, "teacher": "Asmaa Hamdy"},
+          {"order": 16, "teacher": "Nesma Hesham"},
+          {"order": 17, "teacher": "Hagar El-Gohary"},
+          {"order": 18, "teacher": "Mai Awny"},
+          {"order": 19, "teacher": "M.Shokry"},
+          {"order": 20, "teacher": "Hadeer Emad"},
+          {"order": 21, "teacher": "Abdullah Mohamed Shaban"},
+          {"order": 22, "teacher": "Mohamed Samir ( music)"},
+          {"order": 23, "teacher": "Aya Amgad"},
+          {"order": 24, "teacher": "Esraa Adel"},
+          {"order": 25, "teacher": "Ahmad Ragab"},
+          {"order": 26, "teacher": "Nora Amgad"},
+          {"order": 27, "teacher": "Dina Refaat"},
+          {"order": 28, "teacher": "Al-Shimaa Abdelkhalik"},
+          {"order": 29, "teacher": "Amira Samaan"},
+          {"order": 30, "teacher": "Dina Emad"},
+          {"order": 31, "teacher": "Hany Amin"},
+          {"order": 32, "teacher": "Fatma Al-Zahraa"},
+          {"order": 33, "teacher": "Shimaa Desouky"},
+          {"order": 34, "teacher": "Sohaila Elsebaie"},
+          {"order": 35, "teacher": "Mohamed Abdelhakam"}
+        ]
+      }
+    ]
+  },
+  {
+    "day": "Thursday",
+    "supervisor": "Doaa Gamal",
+    "team": "Math + Science + Arabic",
+    "sections": [
+      {
+        "name": "Building Supervision",
+        "assignments": [
+          {"order": 1, "teacher": "Ramadan Omar", "place_task": "Fifth floor in front of the Canteen stairs"},
+          {"order": 2, "teacher": "Reham Younis&Asmaa Khaled", "place_task": "Fourth floor in front of G 12A"},
+          {"order": 3, "teacher": "Mariem Galal", "place_task": "Third Floor in front of the middle stairs"},
+          {"order": 4, "teacher": "Enas Ahmed", "place_task": "Third Floor in front of the accountant's stairs"},
+          {"order": 5, "teacher": "Rofida", "place_task": "Second floor in front of the Canteen stairs"},
+          {"order": 6, "teacher": "Doaa Gamal", "place_task": "Second floor in front of the accountant's stairs"}
+        ]
+      },
+      {
+        "name": "Garden Supervision",
+        "assignments": [
+          {"order": 7, "teacher": "PE", "place_task": "G1& 2"},
+          {"order": 8, "teacher": "PE", "place_task": "G3&4"},
+          {"order": 9, "teacher": "PE", "place_task": "G5&6"},
+          {"order": 10, "teacher": "Aya Adel", "place_task": "G7&8"},
+          {"order": 11, "teacher": "Asmaa Magdy", "place_task": "G9&10"}
+        ]
+      },
+      {
+        "name": "Receiving and giving the students to the drivers",
+        "assignments": [
+          {"order": 12, "teacher": "Ahmad Fahr", "place_task": "Responsible for taking the papers from the drivers and preventing the drivers from entering the school"},
+          {"order": 13, "teacher": "Omar Ahmed", "place_task": "Receiving the papers and getting the students to the drivers."},
+          {"order": 14, "teacher": "Ahmed Mohamed Tokhy"},
+          {"order": 15, "teacher": "Mohamed Abdel Rabea"},
+          {"order": 16, "teacher": "Elina Emad"},
+          {"order": 17, "teacher": "Yasmin Ahmed"},
+          {"order": 18, "teacher": "Hana Adel"},
+          {"order": 19, "teacher": "Rasha Reda"},
+          {"order": 20, "teacher": "Amira Abdelrazik"},
+          {"order": 21, "teacher": "Amany Mohamed"},
+          {"order": 22, "teacher": "Tasneem"},
+          {"order": 23, "teacher": "Mostafa"},
+          {"order": 24, "teacher": "Okasha"},
+          {"order": 25, "teacher": "Amira Faroq"},
+          {"order": 26, "teacher": "Amira Samir"},
+          {"order": 27, "teacher": "Samar Ahmed"},
+          {"order": 28, "teacher": "Toka Adel"},
+          {"order": 29, "teacher": "Roqia"},
+          {"order": 30, "teacher": "Mohamed Abdullah"},
+          {"order": 31, "teacher": "Rahma Mohamed"},
+          {"order": 32, "teacher": "Yasmin Mahmoud"}
+        ]
+      },
+      {
+        "name": "Gates",
+        "assignments": [
+          {"order": 1, "teacher": "Finance gate"},
+          {"order": 2, "teacher": "Middle gate"},
+          {"order": 3, "teacher": "KG & parent gate"},
+          {"order": 4, "teacher": "Main gate"},
+          {"order": 5, "teacher": "Canteen gate"}
+        ]
+      },
+      {
+        "name": "General Supervision",
+        "assignments": [
+          {"order": 1, "teacher": "Hadeer Shafiq"},
+          {"order": 2, "teacher": "Ayman"},
+          {"order": 3, "teacher": "Mohamed Mosalam", "place_task": "General supervision"}
+        ]
+      }
+    ]
+  }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.3
+Flask-SQLAlchemy==3.1.1
+click==8.1.7
+xlrd<2


### PR DESCRIPTION
## Summary
- create a Flask + SQLAlchemy dismissal checker application structure with models for teachers, duty plans, assignments, and attendance
- implement routes, templates, and CLI helpers to import teacher rosters, load the daily dismissal plan, and record attendance with automatic warning tracking
- add fixture data, configuration, dependency list, and documentation for running and using the app

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_b_68dcf88bf1ac8322a390de1408890624